### PR TITLE
make bridge container behave like other mautrix bridges

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,0 @@
-.git/
-.github/
-.idea/
-config/
-data/
-logs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+.github/
+.idea/
+config/
+data/
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN adduser -D -s /bin/sh -u 1000 bridge
 
 # Create application directories
 WORKDIR /app
-RUN mkdir -p /app/logs /app/data /app/config && \
+RUN mkdir -p /app/logs && \
     chown -R bridge:bridge /app
 
 # Copy built applications
@@ -76,51 +76,19 @@ RUN chmod +x /app/steam && \
 # Expose ports
 EXPOSE 50051
 
+# Set default config/registration file path
+ENV CONFIG_FILE="/app/config/config.yaml"
+ENV REGISTRATION_FILE="/app/data/registration.yaml"
+
 # Create entrypoint script
-RUN cat > /app/entrypoint.sh << 'EOF'
-#!/bin/sh
-set -e
-
-# Check if running as root and switch to bridge user
-if [ "$(id -u)" = "0" ]; then
-    echo "Running as root, switching to bridge user"
-    exec su-exec bridge "$0" "$@"
-fi
-
-# Ensure data directory exists and is writable
-if [ ! -w /app/data ]; then
-    echo "Error: /app/data is not writable by bridge user"
-    exit 1
-fi
-
-# Check if config exists
-if [ ! -f /app/config/config.yaml ]; then
-    echo "No config file found at /app/config/config.yaml"
-    echo "Please mount your config file to /app/config/config.yaml"
-    echo "You can use the example config as a starting point:"
-    echo "  docker run -v /path/to/config.yaml:/app/config/config.yaml ..."
-    exit 1
-fi
-
-# Start the bridge
-echo "Starting Matrix Steam Bridge..."
-
-# Check if config needs steam_bridge_path fix for Docker
-if grep -q "steam_bridge_path: ./SteamBridge" /app/config/config.yaml 2>/dev/null; then
-    echo "Fixing steam_bridge_path for Docker environment..."
-    sed -i 's|steam_bridge_path: ./SteamBridge|steam_bridge_path: /app/steamkit-service|g' /app/config/config.yaml
-fi
-
-exec /app/steam -c /app/config/config.yaml "$@"
-EOF
+COPY entrypoint.sh /app/entrypoint.sh
 
 RUN chmod +x /app/entrypoint.sh && chown bridge:bridge /app/entrypoint.sh
 
 # Switch to non-root user
 USER bridge
 
-# Set volumes
-VOLUME ["/app/config", "/app/data", "/app/logs"]
+VOLUME ["/app/logs"]
 
 # Default working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ Supported architectures: `linux/amd64`, `linux/arm64`
    ./steam -c ./config.yaml
    ```
 
+## Configuration w/ Docker
+
+1. Mount the config file folder to your file system
+2. Start the container
+
+   It will generate the configuration file in the config folder (unless you changed its location via environment variable)
+3. Edit the configuration file
+4. Start the container
+
+   It will generate the registration file in the data folder (unless you changed its location via environment variable)
+5. Register the bridge with your homeserver via the registration file and restart your homeserver
+6. Start the container
+
+   It will now start the bridge
+
+Notes:
+- The configuration file will be regenerated with the example if you delete it
+- The registration file will be regerenerated if you delete it, but leave the configuration file there
+
 ## Usage
 
 1. **Invite the bridge bot** to a new Matrix room - it will automatically mark the room as your management portal room

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Supported architectures: `linux/amd64`, `linux/arm64`
 
 Notes:
 - The configuration file will be regenerated with the example if you delete it
-- The registration file will be regerenerated if you delete it, but leave the configuration file there
+- The registration file will be regenerated if you delete it, but leave the configuration file there
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,12 @@ services:
       - ./config:/app/config
       # Mount data directory
       - ./data:/app/data
-      # Mount logs directory
-      - ./logs:/app/logs
+      # Mount logs directory if you want logs to be saved outside the container. Just make sure it is writable by user 1000
+      # - ./logs:/app/logs
+    # If you want to mount differently, use these to configure the configuration and registration files
+    # environment:
+    #  CONFIG_FILE: "/app/data/config.yaml"
+    #  REGISTRATION_FILE: "/app/data/registration.yaml"
     # ports:
     #   # Optional: Expose gRPC port for host access to SteamKit service
     #   - "50051:50051"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,6 @@ if [ ! -f "${CONFIG_FILE}" ]; then
     fi
 
     /app/steam -e -c "${CONFIG_FILE}"
-    # mv /app/config.yaml "${CONFIG_FILE}"
     echo "Edit the config file and restart the container to create the registration."
     exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -e
+
+# Check if running as root and switch to bridge user
+if [ "$(id -u)" = "0" ]; then
+    echo "Running as root, switching to bridge user"
+    exec su-exec bridge "$0" "$@"
+fi
+
+# Ensure data directory is mounted
+if [ ! -d "/app/data" ]; then
+    echo "Error: /app/data does not exist."
+    echo "Please create a mount for it."
+    exit 1
+fi
+
+# Ensure data is writable
+if [ ! -w "/app/data" ]; then
+    echo "Error: /app/data is not writable by bridge user"
+    echo "Ensure it has write permissions for user with ID $(id -u)"
+    exit 1
+fi
+
+if [ ! -w "/app/logs" ]; then
+    echo "Error: /app/logs is not writable by bridge user"
+    echo "Ensure it has write permissions for user with ID $(id -u)"
+    exit 1
+fi
+
+echo "Using Config-file at ${CONFIG_FILE}"
+echo "Using Registration-file at ${REGISTRATION_FILE}"
+
+# Ensure config directory is mounted
+CONFIG_DIR="$(dirname "${CONFIG_FILE}")"
+
+if [ ! -d "${CONFIG_DIR}" ]; then
+    echo "Error: Configuration directory ${CONFIG_DIR} does not exist."
+    echo "Please create a mount for it or change the environment variable CONFIG_FILE"
+    exit 1
+fi
+
+
+# Check if config exists
+if [ ! -f "${CONFIG_FILE}" ]; then
+    echo "No config file found at ${CONFIG_FILE}"
+    echo "Generating one for you"
+
+    if [ ! -w "${CONFIG_DIR}" ]; then
+        echo "Error: Configuration directory ${CONFIG_DIR} not writeable by bridge user."
+        echo "Ensure it has write permissions for user with ID $(id -u)"
+        exit 1
+    fi
+
+    /app/steam -e -c "${CONFIG_FILE}"
+    # mv /app/config.yaml "${CONFIG_FILE}"
+    echo "Edit the config file and restart the container to create the registration."
+    exit 0
+fi
+
+# Check if registration directory is mounted
+REGISTRATION_DIR="$(dirname "${REGISTRATION_FILE}")"
+
+if [ ! -d "${REGISTRATION_DIR}" ]; then
+    echo "Error: Directory ${REGISTRATION_DIR} for the registration file does not exist."
+    echo "Please create a mount for it or change the environment variable REGISTRATION_FILE"
+    exit 1
+fi
+
+if [ ! -f "${REGISTRATION_FILE}" ]; then
+    echo "Generating registration..."
+
+    if [ ! -w "${REGISTRATION_DIR}" ]; then
+        echo "Error: Directory ${REGISTRATION_DIR} for the registration file is not writable by bridge user"
+        echo "Ensure it has write permissions for user with ID $(id -u)"
+        exit 1
+    fi
+    
+    /app/steam -g -c "${CONFIG_FILE}" -r "${REGISTRATION_FILE}"
+    echo "Use the file to register the bridge with your homeserver, restart your homeserver and then start the container again"
+    exit 0
+fi
+
+# Start the bridge
+echo "Starting Matrix Steam Bridge..."
+
+# Check if config needs steam_bridge_path fix for Docker
+if grep -q "steam_bridge_path: ./SteamBridge" "${CONFIG_FILE}" 2>/dev/null; then
+    echo "Fixing steam_bridge_path for Docker environment..."
+    sed -i 's|steam_bridge_path: ./SteamBridge|steam_bridge_path: /app/steamkit-service|g' "${CONFIG_FILE}"
+fi
+
+exec /app/steam -c "${CONFIG_FILE}" "$@"


### PR DESCRIPTION
Make the setup process adhere to the process documented in the [mautrix-documentation](https://docs.mau.fi/bridges/general/docker-setup.html):

1) Starting the container first creates the example config file when no config exists
2) When it exists, the registration file is created if none exists
3) If that exists, the bridge is started

Also: 
- add more verbose/detailed checks for existance of directories before using them
- enable location of config- and registration-file to be configured via environment variable
- document this in `docker-compose.yml`
- update readme to reflect docker configuration process
- had to pull out entrypoint.sh else Dockerfile wouldn't build